### PR TITLE
feat: add config option to ignore user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ http:
           sablierUrl: http://sablier:10000
           group: my-app-group
           sessionDuration: 1m
+          ignoreUserAgent: curl
           dynamic:
             displayName: My Services
             showDetails: true
@@ -79,13 +80,14 @@ http:
 | Option            | Type     | Required | Default                | Description                                                                         |
 | ----------------- | -------- | -------- | ---------------------- | ----------------------------------------------------------------------------------- |
 | `sablierUrl`      | string   | Yes      | `http://sablier:10000` | URL of the Sablier server API (must be reachable from Traefik)                      |
-| `group`           | string   | Yes      | -                      | Group name for managing multiple instances collectively                             |
+| `group`           | string   | Yes      | -                      | Group name for managing multiple instances collectively                         >    |
 | `sessionDuration` | duration | No       | -                      | Duration to keep instances running after the last request (e.g., `1m`, `30s`, `2h`) |
 | `dynamic.displayName`      | string   | No       | Middleware name | Display name shown on the waiting page                                  |
 | `dynamic.showDetails`      | boolean  | No       | Server default  | Show detailed information on the waiting page                           |
 | `dynamic.theme`            | string   | No       | Server default  | Theme for the waiting page (e.g., `hacker-terminal`, `ghost`, `matrix`) |
 | `dynamic.refreshFrequency` | duration | No       | Server default  | How often the waiting page checks if instances are ready                |
 | `blocking.timeout` | duration | No       | -       | Maximum time to wait for instances to become ready |
+| `ignoreUserAgent` | string   | No     | -        | User Agent that should be ignored (middleware sends `HTTP 200` to not wake up the container)
 
 ## Usage
 
@@ -116,6 +118,7 @@ http:
           sessionDuration: 1m               # Session duration before shutting down instances
           # Only one strategy can be used at a time
           # Declare either `dynamic` or `blocking`, not both
+          ignoreUserAgent: curl             # (Optional) Ignore requests with User Agent header curl to not wake up container
 
           # Dynamic strategy: displays a waiting page
           dynamic:

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	splittedNames   []string
 	Dynamic         *DynamicConfiguration  `yaml:"dynamic"`
 	Blocking        *BlockingConfiguration `yaml:"blocking"`
+	IgnoreUserAgent string                 `yaml:"ignoreUserAgent"`
 }
 
 func CreateConfig() *Config {
@@ -39,6 +40,7 @@ func CreateConfig() *Config {
 		splittedNames:   []string{},
 		Dynamic:         nil,
 		Blocking:        nil,
+		IgnoreUserAgent: "",
 	}
 }
 


### PR DESCRIPTION
Added the ability to ignore requests with a configured `User-Agent` Header and send a fake 200 response. This is useful if your services monitored with tools like Uptime Kuma. By 'blocking' a User Agent to start up the container and send them a response.

Issue sablierapp/sablier#708 asked for this feature. And this implements it at the proxy middleware level.

The User Agent that should be ignored can be configured with the following traefik docker label:
```yaml
...
labels:
  - "traefik.http.middlewares.whoamisablier.plugin.sablier.ignoreUserAgent=curl"
...
```

The requests user agent is checked by the substring of the configured one ensuring compatiblity with user agents like `curl/8.7.1`