### PR TITLE
fix(config): empty name and empty group silently built a request with…

### DIFF
--- a/config.go
+++ b/config.go
@@ -59,7 +59,7 @@ func (c *Config) BuildRequest(middlewareName string) (*http.Request, error) {
 		c.splittedNames = names
 	}
 
-	if len(names) == 0 && len(c.Group) == 0 {
+	if len(c.splittedNames) == 0 && len(c.Group) == 0 {
 		return nil, fmt.Errorf("you must specify at least one name or a group")
 	}
 
@@ -151,7 +151,7 @@ func (c *Config) buildBlockingRequest() (*http.Request, error) {
 		_, err = time.ParseDuration(c.SessionDuration)
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing dynamic.sessionDuration: %v", err)
+			return nil, fmt.Errorf("error parsing blocking.sessionDuration: %v", err)
 		}
 
 		q.Add("session_duration", c.SessionDuration)
@@ -169,7 +169,7 @@ func (c *Config) buildBlockingRequest() (*http.Request, error) {
 		_, err := time.ParseDuration(c.Blocking.Timeout)
 
 		if err != nil {
-			return nil, fmt.Errorf("error paring blocking.timeout: %v", err)
+			return nil, fmt.Errorf("error parsing blocking.timeout: %v", err)
 		}
 
 		q.Add("timeout", c.Blocking.Timeout)

--- a/config_test.go
+++ b/config_test.go
@@ -235,6 +235,54 @@ func TestConfig_BuildRequest(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "no names and no group returns error",
+			fields: fields{
+				SablierURL: "http://sablier:10000",
+				Dynamic:    &traefik.DynamicConfiguration{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "no names and no group returns error for blocking",
+			fields: fields{
+				SablierURL: "http://sablier:10000",
+				Blocking:   &traefik.BlockingConfiguration{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "no strategy configured returns error",
+			fields: fields{
+				SablierURL: "http://sablier:10000",
+				Names:      "nginx",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty sablier URL returns error",
+			fields: fields{
+				SablierURL: "",
+				Names:      "nginx",
+				Dynamic:    &traefik.DynamicConfiguration{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "blocking session with invalid session duration",
+			fields: fields{
+				SablierURL:      "http://sablier:10000",
+				Names:           "nginx",
+				SessionDuration: "invalid",
+				Blocking:        &traefik.BlockingConfiguration{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -365,6 +365,7 @@ func TestSablierMiddleware_ServeHTTP_SSE(t *testing.T) {
 
 		sm, err := New(context.Background(), next, &Config{
 			SablierURL:      sablierMockServer.URL,
+			Names:           "nginx",
 			SessionDuration: "1m",
 			Dynamic:         &DynamicConfiguration{},
 		}, "middleware")
@@ -416,6 +417,7 @@ func TestSablierMiddleware_ServeHTTP_SSE(t *testing.T) {
 
 		sm, err := New(context.Background(), next, &Config{
 			SablierURL:      sablierMockServer.URL,
+			Names:           "nginx",
 			SessionDuration: "1m",
 			Dynamic:         &DynamicConfiguration{},
 		}, "middleware")
@@ -458,6 +460,7 @@ func TestSablierMiddleware_ServeHTTP_SSE(t *testing.T) {
 
 		sm, err := New(context.Background(), next, &Config{
 			SablierURL:      sablierMockServer.URL,
+			Names:           "nginx",
 			SessionDuration: "1m",
 			Dynamic:         &DynamicConfiguration{},
 		}, "middleware")
@@ -514,6 +517,7 @@ func TestSablierMiddleware_ServeHTTP_SSE(t *testing.T) {
 
 		sm, err := New(context.Background(), next, &Config{
 			SablierURL:      sablierMockServer.URL,
+			Names:           "nginx",
 			SessionDuration: "1m",
 			Dynamic:         &DynamicConfiguration{},
 		}, "middleware")


### PR DESCRIPTION
… no identifiers instead of returning an error