### PR TITLE
fix: forward sablier status code

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func (sm *SablierMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request
 			}
 		} else {
 			conditonalResponseWriter.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+			conditonalResponseWriter.WriteHeader(resp.StatusCode)
 			_, err := io.Copy(conditonalResponseWriter, resp.Body)
 			if err != nil {
 				http.Error(conditonalResponseWriter, err.Error(), http.StatusInternalServerError)

--- a/main_test.go
+++ b/main_test.go
@@ -19,12 +19,14 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 	type sablier struct {
 		headers map[string]string
 		body    string
+		code    int
 	}
 	tests := []struct {
 		name     string
 		fields   fields
 		sablier  sablier
 		expected string
+		method   string
 		code     int
 	}{
 		{
@@ -42,6 +44,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Dynamic:         &DynamicConfiguration{},
 				},
@@ -63,6 +66,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 					_, _ = fmt.Fprint(w, "response from service")
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Dynamic:         &DynamicConfiguration{},
 				},
@@ -83,6 +87,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 					w.WriteHeader(http.StatusServiceUnavailable)
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Dynamic:         &DynamicConfiguration{},
 				},
@@ -104,6 +109,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 					_, _ = fmt.Fprint(w, "response from service")
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Blocking:        &BlockingConfiguration{},
 				},
@@ -125,6 +131,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 					_, _ = fmt.Fprint(w, "response from service")
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Blocking:        &BlockingConfiguration{},
 				},
@@ -146,6 +153,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 					w.WriteHeader(http.StatusServiceUnavailable)
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Blocking:        &BlockingConfiguration{},
 				},
@@ -168,6 +176,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Dynamic:         &DynamicConfiguration{},
 					IgnoreUserAgent: "curl",
@@ -194,6 +203,7 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 
 				}),
 				Config: &Config{
+					Names:           "nginx",
 					SessionDuration: "1m",
 					Dynamic:         &DynamicConfiguration{},
 					IgnoreUserAgent: "curl",
@@ -205,12 +215,62 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 			expected: "response from service",
 			code:     200,
 		},
+		{
+			name: "sablier response non-200 status code is forwarded when not ready",
+			sablier: sablier{
+				headers: map[string]string{
+					"X-Sablier-Session-Status": "not-ready",
+				},
+				body: "loading page",
+				code: http.StatusAccepted,
+			},
+			fields: fields{
+				Next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					httptrace.ContextClientTrace(r.Context()).WroteHeaders()
+					_, _ = fmt.Fprint(w, "response from service")
+				}),
+				Config: &Config{
+					Names:           "nginx",
+					SessionDuration: "1m",
+					Dynamic:         &DynamicConfiguration{},
+				},
+			},
+			expected: "loading page",
+			code:     http.StatusAccepted,
+		},
+		{
+			name: "blocking mode POST returns 307 when session ready but backend 503",
+			sablier: sablier{
+				headers: map[string]string{
+					"X-Sablier-Session-Status": "ready",
+				},
+				body: "response from sablier",
+			},
+			method: http.MethodPost,
+			fields: fields{
+				Next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// No httptrace callback — simulates Traefik 503 (no backend in pool),
+					// so conditonalResponseWriter.ready stays false.
+					w.WriteHeader(http.StatusServiceUnavailable)
+				}),
+				Config: &Config{
+					Names:           "nginx",
+					SessionDuration: "1m",
+					Blocking:        &BlockingConfiguration{},
+				},
+			},
+			expected: "Temporary Redirect",
+			code:     http.StatusTemporaryRedirect,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sablierMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				for key, value := range tt.sablier.headers {
 					w.Header().Add(key, value)
+				}
+				if tt.sablier.code != 0 {
+					w.WriteHeader(tt.sablier.code)
 				}
 				_, err := w.Write([]byte(tt.sablier.body))
 				if err != nil {
@@ -226,7 +286,11 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 				panic(err)
 			}
 
-			req := httptest.NewRequest(http.MethodGet, "/my-nginx", nil)
+			method := http.MethodGet
+			if tt.method != "" {
+				method = tt.method
+			}
+			req := httptest.NewRequest(method, "/my-nginx", nil)
 			w := httptest.NewRecorder()
 
 			if tt.fields.Headers != nil {


### PR DESCRIPTION
When Sablier did respond with an error, it now properly forward the status code.

Closes #24