### PR TITLE
feat: add keep alive

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -12,6 +12,7 @@ testData:
   names: whoami,nginx               # Comma separated names of containers/services/deployments etc.
   group: default                    # Group name to use to filter by label, ignored if names is set
   sessionDuration: 1m               # The session duration after which containers/services/deployments instances are shutdown
+  keepAliveInterval: 30s            # (optional) How often Sablier is pinged to renew the session while a long-lived connection (SSE, WebSocket, long-polling) is held. Should be shorter than `sessionDuration`. Disabled when omitted.
   # You can only use one strategy at a time
   # To do so, only declare `dynamic` or `blocking`
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ http:
           sablierUrl: http://sablier:10000
           group: my-app-group
           sessionDuration: 1m
+          keepAliveInterval: 30s
           ignoreUserAgent: curl
           dynamic:
             displayName: My Services
@@ -83,6 +84,7 @@ http:
 | `sablierUrl`      | string   | Yes      | `http://sablier:10000` | URL of the Sablier server API (must be reachable from Traefik)                      |
 | `group`           | string   | Yes      | -                      | Group name for managing multiple instances collectively                         >    |
 | `sessionDuration` | duration | No       | -                      | Duration to keep instances running after the last request (e.g., `1m`, `30s`, `2h`) |
+| `keepAliveInterval` | duration | No     | -                      | How often Sablier is pinged to renew the session while a long-lived connection (SSE, WebSocket, long-polling) is held. Should be shorter than `sessionDuration`. Disabled when omitted. |
 | `dynamic.displayName`      | string   | No       | Middleware name | Display name shown on the waiting page                                  |
 | `dynamic.showDetails`      | boolean  | No       | Server default  | Show detailed information on the waiting page                           |
 | `dynamic.theme`            | string   | No       | Server default  | Theme for the waiting page (e.g., `hacker-terminal`, `ghost`, `matrix`) |
@@ -117,6 +119,7 @@ http:
           sablierUrl: http://sablier:10000  # Sablier service URL (must be reachable from Traefik)
           group: my-app-group               # Group name for managing instances collectively
           sessionDuration: 1m               # Session duration before shutting down instances
+          keepAliveInterval: 30s            # (Optional) Re-ping Sablier every 30s to keep long-lived connections alive
           # Only one strategy can be used at a time
           # Declare either `dynamic` or `blocking`, not both
           ignoreUserAgent: curl             # (Optional) Ignore requests with User Agent header curl to not wake up container

--- a/config.go
+++ b/config.go
@@ -22,25 +22,27 @@ type BlockingConfiguration struct {
 type Config struct {
 	SablierURL string `yaml:"sablierUrl"`
 	// Deprecated: use Group instead
-	Names           string `yaml:"names"`
-	Group           string `yaml:"group"`
-	SessionDuration string `yaml:"sessionDuration"`
-	splittedNames   []string
-	Dynamic         *DynamicConfiguration  `yaml:"dynamic"`
-	Blocking        *BlockingConfiguration `yaml:"blocking"`
-	IgnoreUserAgent string                 `yaml:"ignoreUserAgent"`
+	Names             string `yaml:"names"`
+	Group             string `yaml:"group"`
+	SessionDuration   string `yaml:"sessionDuration"`
+	KeepAliveInterval string `yaml:"keepAliveInterval"`
+	splittedNames     []string
+	Dynamic           *DynamicConfiguration  `yaml:"dynamic"`
+	Blocking          *BlockingConfiguration `yaml:"blocking"`
+	IgnoreUserAgent   string                 `yaml:"ignoreUserAgent"`
 }
 
 func CreateConfig() *Config {
 	return &Config{
-		SablierURL:      "http://sablier:10000",
-		Names:           "",
-		Group:           "",
-		SessionDuration: "",
-		splittedNames:   []string{},
-		Dynamic:         nil,
-		Blocking:        nil,
-		IgnoreUserAgent: "",
+		SablierURL:        "http://sablier:10000",
+		Names:             "",
+		Group:             "",
+		SessionDuration:   "",
+		KeepAliveInterval: "",
+		splittedNames:     []string{},
+		Dynamic:           nil,
+		Blocking:          nil,
+		IgnoreUserAgent:   "",
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -9,14 +9,16 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"strings"
+	"time"
 )
 
 type SablierMiddleware struct {
-	client          *http.Client
-	request         *http.Request
-	next            http.Handler
-	useRedirect     bool
-	ignoreUserAgent string
+	client            *http.Client
+	request           *http.Request
+	next              http.Handler
+	useRedirect       bool
+	ignoreUserAgent   string
+	keepAliveInterval time.Duration
 }
 
 // New function creates the configuration
@@ -27,13 +29,25 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		return nil, err
 	}
 
+	var keepAliveInterval time.Duration
+	if config.KeepAliveInterval != "" {
+		keepAliveInterval, err = time.ParseDuration(config.KeepAliveInterval)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing keepAliveInterval: %v", err)
+		}
+		if keepAliveInterval <= 0 {
+			return nil, fmt.Errorf("keepAliveInterval must be positive")
+		}
+	}
+
 	return &SablierMiddleware{
 		request: req,
 		client:  &http.Client{},
 		next:    next,
 		// there is no way to make blocking work in traefik without redirect so let's make it default
-		useRedirect:     config.Blocking != nil,
-		ignoreUserAgent: config.IgnoreUserAgent,
+		useRedirect:       config.Blocking != nil,
+		ignoreUserAgent:   config.IgnoreUserAgent,
+		keepAliveInterval: keepAliveInterval,
 	}, nil
 }
 
@@ -69,6 +83,9 @@ func (sm *SablierMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request
 
 	if resp.Header.Get("X-Sablier-Session-Status") == "ready" {
 		// Check if the backend already received request data
+		if sm.keepAliveInterval > 0 {
+			go sm.keepAlive(req.Context())
+		}
 		trace := &httptrace.ClientTrace{
 			WroteHeaders: func() {
 				conditonalResponseWriter.ready = true
@@ -163,5 +180,25 @@ func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 func (r *responseWriter) Flush() {
 	if flusher, ok := r.responseWriter.(http.Flusher); ok {
 		flusher.Flush()
+	}
+}
+
+// keepAlive periodically sends requests to Sablier to renew the session while a
+// long-lived connection (SSE, WebSocket, long-polling) is held open. It stops
+// as soon as ctx is done, i.e. when the client disconnects.
+func (sm *SablierMiddleware) keepAlive(ctx context.Context) {
+	ticker := time.NewTicker(sm.keepAliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			keepAliveReq := sm.request.Clone(context.Background())
+			resp, err := sm.client.Do(keepAliveReq)
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"sync/atomic"
 	"testing"
 )
 
@@ -254,4 +255,112 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSablierMiddleware_KeepAlive(t *testing.T) {
+	t.Run("sends keep-alive requests to Sablier while connection is held", func(t *testing.T) {
+		// Each request to the mock Sablier server delivers a signal on this channel.
+		sablierRequests := make(chan struct{}, 20)
+
+		sablierMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case sablierRequests <- struct{}{}:
+			default:
+			}
+			w.Header().Add("X-Sablier-Session-Status", "ready")
+			_, _ = w.Write([]byte("response from sablier"))
+		}))
+		defer sablierMockServer.Close()
+
+		sm, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httptrace.ContextClientTrace(r.Context()).WroteHeaders()
+			// Simulate a long-lived connection (SSE/WebSocket): block until disconnected.
+			<-r.Context().Done()
+		}), &Config{
+			SablierURL:        sablierMockServer.URL,
+			Names:             "nginx",
+			SessionDuration:   "1m",
+			Dynamic:           &DynamicConfiguration{},
+			KeepAliveInterval: "20ms",
+		}, "middleware")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		req := httptest.NewRequest(http.MethodGet, "/my-nginx", nil).WithContext(ctx)
+
+		done := make(chan struct{})
+		go func() {
+			sm.ServeHTTP(httptest.NewRecorder(), req)
+			close(done)
+		}()
+
+		// Consume the initial request to Sablier, then wait for two keep-alive pings.
+		// The test will time out (and fail) if keep-alive never fires.
+		<-sablierRequests
+		<-sablierRequests
+		<-sablierRequests
+
+		// Cancel the context to disconnect the client and stop the goroutine.
+		cancel()
+		<-done
+	})
+
+	t.Run("does not send keep-alive requests when disabled", func(t *testing.T) {
+		var count int32
+
+		sablierMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&count, 1)
+			w.Header().Add("X-Sablier-Session-Status", "ready")
+			_, _ = w.Write([]byte("response from sablier"))
+		}))
+		defer sablierMockServer.Close()
+
+		sm, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httptrace.ContextClientTrace(r.Context()).WroteHeaders()
+			_, _ = fmt.Fprint(w, "response from service")
+		}), &Config{
+			SablierURL:      sablierMockServer.URL,
+			Names:           "nginx",
+			SessionDuration: "1m",
+			Dynamic:         &DynamicConfiguration{},
+			// KeepAliveInterval intentionally omitted
+		}, "middleware")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sm.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/my-nginx", nil))
+
+		if got := atomic.LoadInt32(&count); got != 1 {
+			t.Errorf("expected exactly 1 sablier request (no keep-alive), got %d", got)
+		}
+	})
+
+	t.Run("returns error for invalid keepAliveInterval", func(t *testing.T) {
+		_, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), &Config{
+			SablierURL:        "http://sablier:10000",
+			Names:             "nginx",
+			Dynamic:           &DynamicConfiguration{},
+			KeepAliveInterval: "invalid",
+		}, "middleware")
+		if err == nil {
+			t.Error("expected error for invalid keepAliveInterval, got nil")
+		}
+	})
+
+	t.Run("returns error for non-positive keepAliveInterval", func(t *testing.T) {
+		_, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), &Config{
+			SablierURL:        "http://sablier:10000",
+			Names:             "nginx",
+			Dynamic:           &DynamicConfiguration{},
+			KeepAliveInterval: "-5s",
+		}, "middleware")
+		if err == nil {
+			t.Error("expected error for non-positive keepAliveInterval, got nil")
+		}
+	})
 }


### PR DESCRIPTION
Use this if you need long lived connection such as SSE (which never releases the connection) to keep polling in the background and keep the session alive.