### PR TITLE
feat: fail open option

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -13,6 +13,7 @@ testData:
   group: default                    # Group name to use to filter by label, ignored if names is set
   sessionDuration: 1m               # The session duration after which containers/services/deployments instances are shutdown
   keepAliveInterval: 30s            # (optional) How often Sablier is pinged to renew the session while a long-lived connection (SSE, WebSocket, long-polling) is held. Should be shorter than `sessionDuration`. Disabled when omitted.
+  failOpen: false                   # (optional) Pass requests through to the backend when Sablier is unreachable instead of returning HTTP 500.
   ignoreUserAgent:                  # (optional) List of Go regexp patterns; requests whose User-Agent matches any pattern are passed through immediately without waking containers.
     - curl
     - "(?i)uptimerobot"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ http:
           group: my-app-group
           sessionDuration: 1m
           keepAliveInterval: 30s
+          failOpen: false
           ignoreUserAgent:
             - curl
             - "(?i)uptimerobot"
@@ -87,6 +88,7 @@ http:
 | `group`           | string   | Yes      | -                      | Group name for managing multiple instances collectively                         >    |
 | `sessionDuration` | duration | No       | -                      | Duration to keep instances running after the last request (e.g., `1m`, `30s`, `2h`) |
 | `keepAliveInterval` | duration | No     | -                      | How often Sablier is pinged to renew the session while a long-lived connection (SSE, WebSocket, long-polling) is held. Should be shorter than `sessionDuration`. Disabled when omitted. |
+| `failOpen`        | boolean  | No       | `false`                | Pass requests through to the backend when Sablier is unreachable instead of returning `HTTP 500`. |
 | `dynamic.displayName`      | string   | No       | Middleware name | Display name shown on the waiting page                                  |
 | `dynamic.showDetails`      | boolean  | No       | Server default  | Show detailed information on the waiting page                           |
 | `dynamic.theme`            | string   | No       | Server default  | Theme for the waiting page (e.g., `hacker-terminal`, `ghost`, `matrix`) |
@@ -122,6 +124,7 @@ http:
           group: my-app-group               # Group name for managing instances collectively
           sessionDuration: 1m               # Session duration before shutting down instances
           keepAliveInterval: 30s            # (Optional) Re-ping Sablier every 30s to keep long-lived connections alive
+          failOpen: false                   # (Optional) Pass through when Sablier is unreachable instead of returning HTTP 500
           # Only one strategy can be used at a time
           # Declare either `dynamic` or `blocking`, not both
           ignoreUserAgent:                          # (Optional) List of regexp patterns; matching UAs are silently ignored

--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	Group             string `yaml:"group"`
 	SessionDuration   string `yaml:"sessionDuration"`
 	KeepAliveInterval string `yaml:"keepAliveInterval"`
+	FailOpen          bool   `yaml:"failOpen"`
 	splittedNames     []string
 	Dynamic           *DynamicConfiguration  `yaml:"dynamic"`
 	Blocking          *BlockingConfiguration `yaml:"blocking"`
@@ -70,6 +71,7 @@ func CreateConfig() *Config {
 		Group:             "",
 		SessionDuration:   "",
 		KeepAliveInterval: "",
+		FailOpen:          false,
 		splittedNames:     []string{},
 		Dynamic:           nil,
 		Blocking:          nil,

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ type SablierMiddleware struct {
 	request           *http.Request
 	next              http.Handler
 	useRedirect       bool
+	failOpen          bool
 	ignoreUserAgents  []*regexp.Regexp
 	keepAliveInterval time.Duration
 }
@@ -53,6 +54,7 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		next:    next,
 		// there is no way to make blocking work in traefik without redirect so let's make it default
 		useRedirect:       config.Blocking != nil,
+		failOpen:          config.FailOpen,
 		ignoreUserAgents:  ignoreUserAgents,
 		keepAliveInterval: keepAliveInterval,
 	}, nil
@@ -90,6 +92,10 @@ func (sm *SablierMiddleware) ServeHTTP(rw http.ResponseWriter, req *http.Request
 
 	resp, err := sm.client.Do(sablierRequest)
 	if err != nil {
+		if sm.failOpen {
+			sm.next.ServeHTTP(rw, req)
+			return
+		}
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -323,6 +323,77 @@ func TestSablierMiddleware_ServeHTTP(t *testing.T) {
 	}
 }
 
+func TestSablierMiddleware_ServeHTTP_FailOpen(t *testing.T) {
+	closedSablier := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	sablierURL := closedSablier.URL
+	closedSablier.Close()
+
+	t.Run("passes through to backend when Sablier is unreachable and failOpen is enabled", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Backend", "reached")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprint(w, "response from service")
+		})
+
+		sm, err := New(context.Background(), next, &Config{
+			SablierURL:      sablierURL,
+			Names:           "nginx",
+			SessionDuration: "1m",
+			Dynamic:         &DynamicConfiguration{},
+			FailOpen:        true,
+		}, "middleware")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		sm.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/my-nginx", nil))
+
+		res := w.Result()
+		defer res.Body.Close() //nolint:errcheck
+
+		if res.StatusCode != http.StatusAccepted {
+			t.Fatalf("expected status %d, got %d", http.StatusAccepted, res.StatusCode)
+		}
+		if got := res.Header.Get("X-Backend"); got != "reached" {
+			t.Errorf("expected backend header to be preserved, got %q", got)
+		}
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "response from service" {
+			t.Errorf("expected backend body, got %q", body)
+		}
+	})
+
+	t.Run("returns 500 when Sablier is unreachable and failOpen is disabled", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("next handler should not be called")
+		})
+
+		sm, err := New(context.Background(), next, &Config{
+			SablierURL:      sablierURL,
+			Names:           "nginx",
+			SessionDuration: "1m",
+			Dynamic:         &DynamicConfiguration{},
+		}, "middleware")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		sm.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/my-nginx", nil))
+
+		res := w.Result()
+		defer res.Body.Close() //nolint:errcheck
+
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, res.StatusCode)
+		}
+	})
+}
+
 // TestSablierMiddleware_ServeHTTP_SSE tests Server-Sent Events streaming through the middleware.
 //
 // The critical behaviour under test is that SSE events are forwarded to the client when


### PR DESCRIPTION
Adds an opt-in failOpen middleware option.

When enabled, requests passthrough to the target service if Sablier is not reachable.

My goal here is to make Sablier less of a SPOF, allowing already-running services to keep serving traffic in case of Sablier unavailability.

Closes #39