### PR TITLE
feat(config): add readyOnStart option to dynamic strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ http:
             showDetails: true
             theme: hacker-terminal
             refreshFrequency: 5s
+            readyOnStart: false
 ```
 
 | Option            | Type     | Required | Default                | Description                                                                         |
@@ -93,6 +94,7 @@ http:
 | `dynamic.showDetails`      | boolean  | No       | Server default  | Show detailed information on the waiting page                           |
 | `dynamic.theme`            | string   | No       | Server default  | Theme for the waiting page (e.g., `hacker-terminal`, `ghost`, `matrix`) |
 | `dynamic.refreshFrequency` | duration | No       | Server default  | How often the waiting page checks if instances are ready                |
+| `dynamic.readyOnStart` | boolean | No | `false` | Force `X-Sablier-Session-Status: ready` immediately regardless of instance health. No waiting page is shown. |
 | `blocking.timeout` | duration | No       | -       | Maximum time to wait for instances to become ready |
 | `ignoreUserAgent` | string or string\[\] | No     | -        | List of [Go regexp](https://pkg.go.dev/regexp/syntax) patterns. Requests whose `User-Agent` matches any pattern receive an immediate `HTTP 200` without waking the container. Can be specified as a YAML list (preferred) or as a single string (backward-compatible). Patterns are case-sensitive unless the `(?i)` flag is used. |
 

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type DynamicConfiguration struct {
 	ShowDetails      *bool  `yaml:"showDetails"`
 	Theme            string `yaml:"theme"`
 	RefreshFrequency string `yaml:"refreshFrequency"`
+	ReadyOnStart     *bool  `yaml:"readyOnStart"`
 }
 
 type BlockingConfiguration struct {
@@ -163,6 +164,10 @@ func (c *Config) buildDynamicRequest(middlewareName string) (*http.Request, erro
 
 	if c.Dynamic.ShowDetails != nil {
 		q.Add("show_details", strconv.FormatBool(*c.Dynamic.ShowDetails))
+	}
+
+	if c.Dynamic.ReadyOnStart != nil {
+		q.Add("ready_on_start", strconv.FormatBool(*c.Dynamic.ReadyOnStart))
 	}
 
 	request.URL.RawQuery = q.Encode()

--- a/config_test.go
+++ b/config_test.go
@@ -153,6 +153,18 @@ func TestConfig_BuildRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "dynamic session with readyOnStart",
+			fields: fields{
+				SablierURL: "http://sablier:10000",
+				Names:      "nginx",
+				Dynamic: &traefik.DynamicConfiguration{
+					ReadyOnStart: &tru,
+				},
+			},
+			want:    createRequest("GET", "http://sablier:10000/api/strategies/dynamic?display_name=sablier-middleware&names=nginx&ready_on_start=true", nil),
+			wantErr: false,
+		},
+		{
 			name: "dynamic session without show details set",
 			fields: fields{
 				SablierURL:      "http://sablier:10000",


### PR DESCRIPTION
## What

Adds `ready_on_start` query parameter to the dynamic strategy. When `true`, Sablier returns `X-Sablier-Session-Status: ready` immediately regardless of instance health — the reverse proxy passes the request through without showing a waiting page.

The per-instance `sablier.ready-on-start` label controls behavior per container. The query param does the same, but at the middleware level — no labels needed.

## Why

Sometimes you want different behavior depending on which service is accessed:

**Home Assistant + Frigate:** When loading the HA dashboard, you want Frigate to start in the background — no need to wait. But when accessing Frigate's own UI directly, you want the waiting screen to confirm it's ready.
**Chat app + LiteLLM proxy:** When users open the chat, LiteLLM starts alongside without blocking. Direct access to LiteLLM UI get the waiting screen.

## Usage

GET /api/strategies/dynamic?group=myapp&ready_on_start=true

Plugin-side config (separate PRs):
```yaml
    frigate-sablier:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate

    frigate-sablier-force:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate
            readyOnStart: true
```