### PR TITLE
fix: preserve backend Set-Cookie headers when flushing buffered headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,18 @@ func (r *responseWriter) WriteHeader(code int) {
 
 	headers := r.responseWriter.Header()
 	for header, value := range r.headers {
-		headers[header] = value
+		// Set-Cookie is multi-valued: each value is an independent cookie.
+		// The buffered map may hold cookies written before the backend
+		// replied (e.g. Traefik's sticky-session cookie, written by the
+		// load balancer before proxying), while the real writer already
+		// holds the cookies of the backend response. Overwriting would
+		// drop the backend cookies (e.g. an OIDC state cookie), so append
+		// instead.
+		if header == "Set-Cookie" {
+			headers[header] = append(headers[header], value...)
+		} else {
+			headers[header] = value
+		}
 	}
 
 	r.responseWriter.WriteHeader(code)

--- a/main_test.go
+++ b/main_test.go
@@ -970,3 +970,78 @@ func TestSablierMiddleware_KeepAlive(t *testing.T) {
 		}
 	})
 }
+
+func TestResponseWriter_WriteHeader_PreservesBackendSetCookie(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rw := newResponseWriter(recorder)
+
+	// A handler running before the backend replied writes into the buffered
+	// headers — this is what Traefik's sticky-session load balancer does
+	// right before proxying the request.
+	http.SetCookie(rw, &http.Cookie{Name: "lb", Value: "server-1", Path: "/"})
+
+	// The reverse proxy sent the request (httptrace fired) and copies the
+	// backend response headers onto the real writer.
+	rw.ready = true
+	rw.Header().Add("Set-Cookie", "state=abc123; Path=/; HttpOnly")
+
+	rw.WriteHeader(http.StatusFound)
+
+	cookies := recorder.Header().Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("expected both the sticky and the backend Set-Cookie headers, got %d: %v", len(cookies), cookies)
+	}
+}
+
+func TestSablierMiddleware_ServeHTTP_PreservesBackendSetCookie(t *testing.T) {
+	readySablier := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Sablier-Session-Status", "ready")
+		_, _ = w.Write([]byte("ready"))
+	}))
+	defer readySablier.Close()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// What Traefik's sticky-session load balancer does before proxying:
+		// the cookie lands in the buffered headers (writer not ready yet).
+		http.SetCookie(w, &http.Cookie{Name: "lb", Value: "server-1", Path: "/"})
+
+		// The proxy sends the request to the backend...
+		httptrace.ContextClientTrace(r.Context()).WroteHeaders()
+
+		// ...and copies the backend response headers and status.
+		w.Header().Add("Set-Cookie", "state=abc123; Path=/; HttpOnly")
+		w.WriteHeader(http.StatusFound)
+	})
+
+	sm, err := New(context.Background(), next, &Config{
+		SablierURL:      readySablier.URL,
+		Names:           "nginx",
+		SessionDuration: "1m",
+		Dynamic:         &DynamicConfiguration{},
+	}, "middleware")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	sm.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/my-nginx", nil))
+
+	res := w.Result()
+	defer res.Body.Close() //nolint:errcheck
+
+	cookies := res.Header.Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("expected both the sticky and the backend Set-Cookie headers, got %d: %v", len(cookies), cookies)
+	}
+	for _, want := range []string{"lb=server-1", "state=abc123"} {
+		found := false
+		for _, c := range cookies {
+			if strings.HasPrefix(c, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a Set-Cookie header starting with %q, got %v", want, cookies)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #57.

**What**

`responseWriter.WriteHeader` merges the buffered headers into the real writer by assignment. When Traefik's sticky-session load balancer writes its cookie before proxying (the writer is not `ready` yet, so the cookie is buffered), the merge overwrites the `Set-Cookie` headers that the backend set on its response — e.g. an OIDC state cookie — and login flows behind sticky services fail with `400 Bad Request` on the OAuth callback (full mechanism and reproduction in #57).

**How**

`Set-Cookie` is multi-valued (each value is an independent cookie), so it is now merged by appending the buffered values instead of overwriting; every other header keeps the existing overwrite semantics.

**Tests**

- `TestResponseWriter_WriteHeader_PreservesBackendSetCookie` — unit-level: buffered sticky cookie + backend cookie on the real writer must both survive `WriteHeader`.
- `TestSablierMiddleware_ServeHTTP_PreservesBackendSetCookie` — end-to-end through `ServeHTTP`: next handler writes a sticky cookie before firing the `httptrace` callback (exactly what Traefik's load balancer + proxy do), then adds the backend cookie; both must reach the client.

Both fail on `main` and pass with the fix. Also verified against a live Traefik v3.6.11 (local plugin, file provider, sticky service): with the fix, the client receives both the sticky and the backend cookie.