### PR TITLE
fix: discard buffered headers of the dropped 503 response

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,6 +191,16 @@ func (r *responseWriter) WriteHeader(code int) {
 		// will never return false in case there was a connection established to
 		// the backend server and so we can be sure that the 503 was produced
 		// inside Traefik already
+		//
+		// The whole 503 response is discarded: its body is dropped by Write
+		// and its status is never forwarded, so the headers it wrote must be
+		// dropped too. http.Error — used by Traefik's load balancer when the
+		// service has no available server — writes "Content-Type: text/plain;
+		// charset=utf-8" and "X-Content-Type-Options: nosniff" into the
+		// buffered headers; left in place, they would leak into the waiting
+		// page on the final flush and override its text/html Content-Type
+		// (the page then renders as plain text).
+		r.headers = make(http.Header)
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -970,3 +970,46 @@ func TestSablierMiddleware_KeepAlive(t *testing.T) {
 		}
 	})
 }
+
+func TestSablierMiddleware_ServeHTTP_WaitingPageContentTypeAfterLB503(t *testing.T) {
+	// Session is "ready" for Sablier (instances started) but the Kubernetes
+	// Service still has no endpoint (pods not Ready yet) — the request reaches
+	// the load balancer, which aborts with a 503.
+	readySablier := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Sablier-Session-Status", "ready")
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!DOCTYPE html><html>waiting page</html>"))
+	}))
+	defer readySablier.Close()
+
+	// What Traefik's load balancer does when the (scaled-to-zero) service has
+	// no endpoint: http.Error writes "Content-Type: text/plain; charset=utf-8"
+	// and "X-Content-Type-Options: nosniff" — into the buffered headers, since
+	// no backend was reached and the writer is not ready.
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no available server", http.StatusServiceUnavailable)
+	})
+
+	sm, err := New(context.Background(), next, &Config{
+		SablierURL:      readySablier.URL,
+		Names:           "nginx",
+		SessionDuration: "1m",
+		Dynamic:         &DynamicConfiguration{},
+	}, "middleware")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	sm.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/my-nginx", nil))
+
+	res := w.Result()
+	defer res.Body.Close() //nolint:errcheck
+
+	if got := res.Header.Get("Content-Type"); got != "text/html" {
+		t.Errorf("expected the waiting page Content-Type %q, got %q", "text/html", got)
+	}
+	if got := res.Header.Get("X-Content-Type-Options"); got != "" {
+		t.Errorf("expected no X-Content-Type-Options leaked from the discarded 503, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #59.

**What**

When the load balancer aborts with `http.Error(503)` (service with no available server — typical for a scaled-to-zero backend whose session is ready but whose pods are still starting), the buffering writer drops the 503's status and body but keeps the headers `http.Error` wrote into the buffered map (`Content-Type: text/plain; charset=utf-8`, `X-Content-Type-Options: nosniff`). The final `WriteHeader` flush then merges them over the waiting page's own headers: the page is served as `text/plain` and browsers render the raw HTML as text (full mechanism in #59).

**How**

Reset the buffered header map inside the not-ready-503 guard: if the 503 response is discarded, everything it wrote is discarded, headers included.

**Tests**

`TestSablierMiddleware_ServeHTTP_WaitingPageContentTypeAfterLB503` — end-to-end through `ServeHTTP`: Sablier answers `ready` + `Content-Type: text/html`, the next handler does `http.Error(503)` without firing the httptrace callbacks (exactly what Traefik's load balancer does with no backend). Asserts the waiting page keeps `Content-Type: text/html` and no `X-Content-Type-Options` leaks. Fails on `main`, passes with the fix.

Independent from #58 (different lines, both branches based on `main`); together they cover the two ways the buffered flush corrupts the final response.